### PR TITLE
Cleanup .cabal file

### DIFF
--- a/MakeReservation.cabal
+++ b/MakeReservation.cabal
@@ -40,7 +40,7 @@ build-type:          Simple
 
 -- Extra files to be distributed with the package, such as examples or a
 -- README.
-extra-source-files:  ChangeLog.md
+extra-source-files:
 
 -- Constraint on the version of Cabal needed to build this package.
 cabal-version:       >=1.10


### PR DESCRIPTION
This addresses the following warning, when running `stack build`:

```
Warning: File listed in MakeReservation.cabal file does not exist: ChangeLog.md
```