### PR TITLE
Fill other-modules section in .cabal file

### DIFF
--- a/MakeReservation.cabal
+++ b/MakeReservation.cabal
@@ -51,7 +51,13 @@ executable MakeReservation
   main-is:             Main.hs
 
   -- Modules included in this executable, other than Main.
-  -- other-modules:
+  other-modules:
+    CommandLine
+    OpeningJson
+    ReservationJson
+    ReservationsApi
+    ReservationsHttpClient
+    Wizard
 
   -- LANGUAGE extensions used by modules in this package.
   other-extensions:    DeriveFunctor


### PR DESCRIPTION
This addresses the following warning:

```
Warning: The following modules should be added to exposed-modules or other-modules [..]:
    - In MakeReservation component:
        CommandLine
        OpeningJson
        ReservationJson
        ReservationsApi
        ReservationsHttpClient
        Wizard
```